### PR TITLE
Add GET entries endpoint

### DIFF
--- a/diarydepresiku/backend/app/dao.py
+++ b/diarydepresiku/backend/app/dao.py
@@ -1,0 +1,12 @@
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+class DiaryDao:
+    """Data access object for DiaryEntry operations."""
+
+    @staticmethod
+    def getAllEntries(db: Session):
+        """Return all diary entries from the database."""
+        return db.query(models.DiaryEntry).all()

--- a/diarydepresiku/backend/app/main.py
+++ b/diarydepresiku/backend/app/main.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from . import models, schemas, database
 from .database import engine, get_db
+from .dao import DiaryDao
 
 # Membuat objek FastAPI
 app = FastAPI()
@@ -20,6 +21,14 @@ def create_entry(entry: schemas.EntryCreate, db: Session = Depends(get_db)):
     db.commit()  # simpan perubahan
     db.refresh(db_entry)  # mengambil data lengkap (termasuk id dari database)
     return db_entry  # akan otomatis dikonversi ke schema Entry (Pydantic)
+
+
+# Endpoint untuk mendapatkan semua entri diary
+@app.get("/entries", response_model=list[schemas.Entry])
+def read_entries(db: Session = Depends(get_db)):
+    """Return all diary entries from the database."""
+    entries = DiaryDao.getAllEntries(db)
+    return entries
 
 # Endpoint dummy untuk analisis AI terhadap teks diary
 @app.post("/analyze", response_model=schemas.AnalyzeResponse)


### PR DESCRIPTION
## Summary
- add Dao abstraction for retrieving diary entries
- expose `/entries` GET route using DiaryDao

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684066f716cc8324bcc2192378bf1c93