### PR TITLE
Make backend URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ _Aplikasi Mobile Pendamping Kesehatan Mental_
 - API RESTful: autentikasi, entri, analisis, konten
 - Keamanan: HTTPS, token auth, enkripsi, audit log
 
+#### Konfigurasi Base URL
+Jika backend dijalankan di alamat selain `http://10.0.2.2:8000`, ubah nilai
+`BASE_URL` pada file `ApiConfig.kt`. Alamat tersebut digunakan oleh aplikasi
+Android untuk terhubung ke server FastAPI.
+
 ---
 
 ## 🤖 AI & Sistem Rekomendasi

--- a/diarydepresiku/client/app/src/main/kotlin/com/example/diarydepresiku/ApiConfig.kt
+++ b/diarydepresiku/client/app/src/main/kotlin/com/example/diarydepresiku/ApiConfig.kt
@@ -1,0 +1,6 @@
+package com.example.diarydepresiku
+
+object ApiConfig {
+    // Base URL untuk backend FastAPI. Ubah nilainya sesuai alamat server.
+    const val BASE_URL: String = "http://10.0.2.2:8000/"
+}

--- a/diarydepresiku/client/app/src/main/kotlin/com/example/diarydepresiku/DiaryRepository.kt
+++ b/diarydepresiku/client/app/src/main/kotlin/com/example/diarydepresiku/DiaryRepository.kt
@@ -12,9 +12,9 @@ class DiaryRepository(context: Context) {
     private val db = DiaryDatabase.getDatabase(context)
     private val diaryDao = db.diaryDao()
 
-    // Inisialisasi Retrofit untuk API (misal base URL lokal/emulator)
+    // Inisialisasi Retrofit untuk API menggunakan base URL dari konfigurasi
     private val retrofit = Retrofit.Builder()
-        .baseUrl("http://10.0.2.2:8000/") // 10.0.2.2 = localhost untuk emulator Android
+        .baseUrl(ApiConfig.BASE_URL)
         .addConverterFactory(GsonConverterFactory.create())
         .build()
     private val diaryApi = retrofit.create(DiaryApi::class.java)


### PR DESCRIPTION
## Summary
- allow Retrofit base URL to be read from `ApiConfig`
- document how to change the base URL for another backend host

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684067a6da288324968b59097c7e3526