### PR TITLE
Add gradle config for Android client

### DIFF
--- a/diarydepresiku/client/app/build.gradle
+++ b/diarydepresiku/client/app/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+}
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.example.diarydepresiku"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion "1.4.7"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.22"
+    implementation 'androidx.core:core-ktx:1.10.1'
+
+    // Jetpack Compose
+    implementation "androidx.compose.ui:ui:1.4.3"
+    implementation "androidx.compose.material:material:1.4.3"
+    implementation "androidx.activity:activity-compose:1.7.2"
+
+    // Room
+    implementation "androidx.room:room-runtime:2.5.1"
+    kapt "androidx.room:room-compiler:2.5.1"
+    implementation "androidx.room:room-ktx:2.5.1"
+
+    // Retrofit
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.9.0"
+
+    // Coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1"
+}

--- a/diarydepresiku/client/app/src/main/AndroidManifest.xml
+++ b/diarydepresiku/client/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.diarydepresiku">
+
+    <application
+        android:allowBackup="true"
+        android:label="Diary Depresiku"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar">
+        <activity android:name=".MainActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/diarydepresiku/client/settings.gradle
+++ b/diarydepresiku/client/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "DiaryDepresiku"
+include(":app")


### PR DESCRIPTION
## Summary
- add `build.gradle` for the Android `app` module
- declare `MainActivity` in an `AndroidManifest.xml`
- provide a `settings.gradle` to make the client buildable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406d3b760c83248fe8624d5163aacc